### PR TITLE
Fix ZZL-7 and MPEP links to canonical files

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -19,14 +19,14 @@
 /isrib-a15                /product_isrib_A15.html                      301
 /isrib-original           /product_isrib.html                          301
 /isrib                    /product_isrib.html                          301
-/zzl-7                    /zzl7.html                                   301
-/mpep-oxalate            /mpep.html                                   301
+/zzl-7                    /product_zzl_7.html                                   301
+/mpep-oxalate            /product_MPEP.html                                   301
 
 # Legacy product URLs
 /products/isrib-a15       /product_isrib_A15.html                      301
 /products/isrib           /product_isrib.html                          301
-/products/zzl7            /zzl7.html                                   301
-/products/mpep            /mpep.html                                   301
+/products/zzl7            /product_zzl_7.html                                   301
+/products/mpep            /product_MPEP.html                                   301
 
 # General order redirect
 /order                    /contact?inquiry=order                        301
@@ -35,8 +35,8 @@
 # Product anchors to individual pages
 /products#isrib-a15       /product_isrib_A15.html                      301
 /products#isrib           /product_isrib.html                          301
-/products#zzl7            /zzl7.html                                   301
-/products#mpep            /mpep.html                                   301
+/products#zzl7            /product_zzl_7.html                                   301
+/products#mpep            /product_MPEP.html                                   301
 
 # SPA fallback for all other routes
 /*                        /index.html                                   200

--- a/about.html
+++ b/about.html
@@ -291,8 +291,8 @@
                     <ul>
                         <li><a href="product_isrib_A15.html">ISRIB-A15</a></li>
                         <li><a href="product_isrib.html">ISRIB Original</a></li>
-                        <li><a href="zzl7.html">ZZL-7</a></li>
-                        <li><a href="mpep.html">MPEP Oxalate</a></li>
+                        <li><a href="product_zzl_7.html">ZZL-7</a></li>
+                        <li><a href="product_MPEP.html">MPEP Oxalate</a></li>
                         <li><a href="products.html">All Products</a></li>
                     </ul>
                 </div>

--- a/contact.html
+++ b/contact.html
@@ -252,8 +252,8 @@
                     <ul>
                         <li><a href="product_isrib_A15.html">ISRIB-A15</a></li>
                         <li><a href="product_isrib.html">ISRIB Original</a></li>
-                        <li><a href="zzl7.html">ZZL-7</a></li>
-                        <li><a href="mpep.html">MPEP Oxalate</a></li>
+                        <li><a href="product_zzl_7.html">ZZL-7</a></li>
+                        <li><a href="product_MPEP.html">MPEP Oxalate</a></li>
                         <li><a href="products.html">All Products</a></li>
                     </ul>
                 </div>

--- a/faq.html
+++ b/faq.html
@@ -249,8 +249,8 @@
                     <ul>
                         <li><a href="product_isrib_A15.html">ISRIB-A15</a></li>
                         <li><a href="product_isrib.html">ISRIB Original</a></li>
-                        <li><a href="zzl7.html">ZZL-7</a></li>
-                        <li><a href="mpep.html">MPEP Oxalate</a></li>
+                        <li><a href="product_zzl_7.html">ZZL-7</a></li>
+                        <li><a href="product_MPEP.html">MPEP Oxalate</a></li>
                         <li><a href="products.html">All Products</a></li>
                     </ul>
                 </div>

--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
                     <div class="product-footer">
                         <div class="price-range">$50 - $200</div>
                         <div class="product-buttons">
-                            <a href="zzl7.html" class="view-product">View Details</a>
+                            <a href="product_zzl_7.html" class="view-product">View Details</a>
                             <a href="contact.html?product=zzl7&inquiry=order" class="add-to-cart" onclick="trackCTA('product', 'zzl7')">Contact to Order</a>
                         </div>
                     </div>
@@ -331,7 +331,7 @@
                     <div class="product-footer">
                         <div class="price-range">$45 - $450</div>
                         <div class="product-buttons">
-                            <a href="mpep.html" class="view-product">View Details</a>
+                            <a href="product_MPEP.html" class="view-product">View Details</a>
                             <a href="contact.html?product=mpep&inquiry=order" class="add-to-cart" onclick="trackCTA('product', 'mpep')">Contact to Order</a>
                         </div>
                     </div>
@@ -467,8 +467,8 @@
                     <ul>
                         <li><a href="product_isrib_A15.html">ISRIB-A15</a></li>
                         <li><a href="product_isrib.html">ISRIB Original</a></li>
-                        <li><a href="zzl7.html">ZZL-7</a></li>
-                        <li><a href="mpep.html">MPEP Oxalate</a></li>
+                        <li><a href="product_zzl_7.html">ZZL-7</a></li>
+                        <li><a href="product_MPEP.html">MPEP Oxalate</a></li>
                         <li><a href="products.html">All Products</a></li>
                     </ul>
                 </div>

--- a/product_MPEP.html
+++ b/product_MPEP.html
@@ -531,8 +531,8 @@
                     <ul>
                         <li><a href="product_isrib_A15.html">ISRIB-A15</a></li>
                         <li><a href="product_isrib.html">ISRIB</a></li>
-                        <li><a href="zzl7.html">ZZL-7</a></li>
-                        <li><a href="mpep.html">MPEP Oxalate</a></li>
+                        <li><a href="product_zzl_7.html">ZZL-7</a></li>
+                        <li><a href="product_MPEP.html">MPEP Oxalate</a></li>
                         <li><a href="products.html">All Products</a></li>
                     </ul>
                 </div>

--- a/product_isrib.html
+++ b/product_isrib.html
@@ -522,8 +522,8 @@
                     <ul>
                         <li><a href="product_isrib_A15.html">ISRIB-A15</a></li>
                         <li><a href="product_isrib.html">ISRIB</a></li>
-                        <li><a href="zzl7.html">ZZL-7</a></li>
-                        <li><a href="mpep.html">MPEP Oxalate</a></li>
+                        <li><a href="product_zzl_7.html">ZZL-7</a></li>
+                        <li><a href="product_MPEP.html">MPEP Oxalate</a></li>
                         <li><a href="products.html">All Products</a></li>
                     </ul>
                 </div>

--- a/product_isrib_A15.html
+++ b/product_isrib_A15.html
@@ -522,8 +522,8 @@
                     <ul>
                         <li><a href="isrib-a15.html">ISRIB-A15</a></li>
                         <li><a href="isrib.html">ISRIB Original</a></li>
-                        <li><a href="zzl7.html">ZZL-7</a></li>
-                        <li><a href="mpep.html">MPEP Oxalate</a></li>
+                        <li><a href="product_zzl_7.html">ZZL-7</a></li>
+                        <li><a href="product_MPEP.html">MPEP Oxalate</a></li>
                         <li><a href="products.html">All Products</a></li>
                     </ul>
                 </div>

--- a/product_zzl_7.html
+++ b/product_zzl_7.html
@@ -523,8 +523,8 @@
                     <ul>
                         <li><a href="product_isrib_A15.html">ISRIB-A15</a></li>
                         <li><a href="product_isrib.html">ISRIB</a></li>
-                        <li><a href="zzl7.html">ZZL-7</a></li>
-                        <li><a href="mpep.html">MPEP Oxalate</a></li>
+                        <li><a href="product_zzl_7.html">ZZL-7</a></li>
+                        <li><a href="product_MPEP.html">MPEP Oxalate</a></li>
                         <li><a href="products.html">All Products</a></li>
                     </ul>
                 </div>

--- a/products.html
+++ b/products.html
@@ -252,7 +252,7 @@
                             <span class="price-per-mg">($0.50/mg)</span>
                         </div>
                         <div class="product-buttons">
-                            <a href="zzl7.html" class="view-product">View Details</a>
+                            <a href="product_zzl_7.html" class="view-product">View Details</a>
                             <a href="contact.html?product=zzl7-100mg&price=50&inquiry=order" class="add-to-cart contact-to-order" onclick="trackCTA('product', 'zzl7', 'contact_to_order')">Contact to Order</a>
                         </div>
                     </div>
@@ -317,7 +317,7 @@
                             <span class="price-per-mg">($0.90/mg)</span>
                         </div>
                         <div class="product-buttons">
-                            <a href="mpep.html" class="view-product">View Details</a>
+                            <a href="product_MPEP.html" class="view-product">View Details</a>
                             <a href="contact.html?product=mpep-50mg&price=45&inquiry=order" class="add-to-cart contact-to-order" onclick="trackCTA('product', 'mpep', 'contact_to_order')">Contact to Order</a>
                         </div>
                     </div>
@@ -383,8 +383,8 @@
                     <ul>
                         <li><a href="product_isrib_A15.html">ISRIB-A15</a></li>
                         <li><a href="product_isrib.html">ISRIB Original</a></li>
-                        <li><a href="zzl7.html">ZZL-7</a></li>
-                        <li><a href="mpep.html">MPEP Oxalate</a></li>
+                        <li><a href="product_zzl_7.html">ZZL-7</a></li>
+                        <li><a href="product_MPEP.html">MPEP Oxalate</a></li>
                         <li><a href="products.html">All Products</a></li>
                     </ul>
                 </div>


### PR DESCRIPTION
## Summary
- replace all zzl7.html and mpep.html references with the canonical product_zzl_7.html and product_MPEP.html files across the site
- update Netlify redirect targets so friendly URLs resolve to the new filenames

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d10afe0cec8322a9f3572806fb106f