### PR TITLE
Move CTA tracking to main bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,30 +47,6 @@
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
         gtag('config', 'G-KMHX8Y9P2L');
-        
-        // CTA click tracking
-        function trackCTA(location, product = null) {
-            gtag('event', 'contact_intent', {
-                'event_category': 'engagement',
-                'event_label': location,
-                'product': product
-            });
-            
-            // Meta Pixel
-            if (typeof fbq !== 'undefined') {
-                fbq('track', 'Contact', {
-                    content_name: product || 'General Inquiry',
-                    content_category: 'Research Chemicals'
-                });
-            }
-            
-            // Reddit Pixel
-            if (typeof rdt !== 'undefined') {
-                rdt('track', 'Contact', {
-                    item_name: product || 'General Inquiry'
-                });
-            }
-        }
     </script>
     
     <!-- External CSS -->
@@ -507,6 +483,8 @@
             💬 Contact to Order
         </a>
     </div>
+
+    <script src="js/main.js"></script>
 
         <!--Start of Tawk.to Script-->
 <script type="text/javascript">

--- a/js/main.js
+++ b/js/main.js
@@ -620,10 +620,44 @@ function quickOrder(productName, quantity, price) {
 
 // Global CTA tracking function
 function trackCTA(location, product = null, action = null) {
+    const eventData = {
+        event_category: 'engagement',
+        event_label: location
+    };
+
+    if (product) {
+        eventData.product = product;
+    }
+
+    if (action) {
+        eventData.action = action;
+    }
+
+    if (typeof gtag !== 'undefined') {
+        gtag('event', 'contact_intent', eventData);
+    }
+
+    const contactDescriptor = product || action || 'General Inquiry';
+
+    if (typeof fbq !== 'undefined') {
+        fbq('track', 'Contact', {
+            content_name: contactDescriptor,
+            content_category: 'Research Chemicals',
+            event_label: location
+        });
+    }
+
+    if (typeof rdt !== 'undefined') {
+        rdt('track', 'Contact', {
+            item_name: contactDescriptor,
+            event_label: location
+        });
+    }
+
     trackEvent('cta_click', {
-        location: location,
-        product: product,
-        action: action
+        location,
+        product,
+        action
     });
 }
 


### PR DESCRIPTION
## Summary
- move the CTA analytics helper from inline script into `js/main.js`
- expand the helper to trigger GA, Meta Pixel, and Reddit Pixel tracking with location, product, and action metadata
- remove the redundant inline definition and load the shared bundle on the home page

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d11259041c83229fc3ab84363dd625