### PR TITLE
Refine Netlify redirects for friendly URLs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -38,5 +38,15 @@
 /products#zzl7            /product_zzl_7.html                                   301
 /products#mpep            /product_MPEP.html                                   301
 
-# SPA fallback for all other routes
-/*                        /index.html                                   200
+# Friendly URLs for core pages
+/products               /products.html                              200
+/about                  /about.html                                 200
+/faq                    /faq.html                                   200
+/contact                /contact.html                               200
+/quality                /quality.html                               200
+/safety                 /safety.html                                200
+/research               /research.html                              200
+/privacy                /privacy.html                               200
+/terms                  /terms.html                                 200
+/disclaimer             /disclaimer.html                            200
+/success                /success.html                               200


### PR DESCRIPTION
## Summary
- remove the catch-all SPA redirect so Netlify can serve the built-in 404 handler
- add explicit rewrite rules that map clean URLs to the corresponding static HTML pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d11ae7d6908322907cf0a23a9245fc