### PR TITLE
Adjust Netlify cache headers for HTML vs static assets

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -52,7 +52,7 @@
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     
     # Cache control
-    Cache-Control = "public, max-age=31536000, immutable"
+    Cache-Control = "public, max-age=0, must-revalidate"
 
 # CSS files caching
 [[headers]]
@@ -76,7 +76,7 @@
 [[headers]]
   for = "/*.html"
   [headers.values]
-    Cache-Control = "public, max-age=3600"
+    Cache-Control = "public, max-age=0, must-revalidate"
 
 # API endpoints (no cache)
 [[headers]]


### PR DESCRIPTION
## Summary
- reduce the default Cache-Control for the site-wide header block so HTML responses are not cached long-term
- ensure the HTML-specific headers also use a short max-age while keeping long-lived caching for CSS and JS assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d11eac787c832291515b51506deb90